### PR TITLE
Update code_editor.php，fix-cdn-url

### DIFF
--- a/配套插件/BsCore/fields/code_editor/code_editor.php
+++ b/配套插件/BsCore/fields/code_editor/code_editor.php
@@ -14,7 +14,9 @@ if (!class_exists('CSF_Field_code_editor')) {
     {
 
         public $version = '5.65.2';
-        public $cdn_url = 'https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-M/codemirror/';
+        //字节跳动CDN失效，更换为cdnjs
+        // public $cdn_url = 'https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-M/codemirror/';
+        public $cdn_url = 'https://cdnjs.cloudflare.com/ajax/libs/codemirror/';
         public $theme_url = 'https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/codemirror/5.65.2/theme/shadowfox.min.css';
 
         public function __construct($field, $value = '', $unique = '', $where = '', $parent = '')


### PR DESCRIPTION
通过更换CDN源修复了代码编辑器失效的问题，请作者大大检查下其他用字节源的位置，貌似不太稳定，不同有效期的链接也有404的情况
<img width="1656" height="515" alt="Snipaste_2025-07-22_14-56-56" src="https://github.com/user-attachments/assets/9095b1e7-eef5-4441-8013-05e033bbde9c" />
